### PR TITLE
Loosen timezone parsing to also accept 'Z' as timezone

### DIFF
--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
@@ -44,7 +44,7 @@ public class LogEvent {
     public static final String KAFKA_KEY = "kafkaKey";
 
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
-            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSZ")
+            .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX")
             .withZone( ZoneId.systemDefault());
 
     private Instant time;


### PR DESCRIPTION
As per: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html

```
   X       zone-offset 'Z' for zero    offset-X          Z; -08; -0830; -08:30; -083015; -08:30:15;
   x       zone-offset                 offset-x          +0000; -08; -0830; -08:30; -083015; -08:30:15;
   Z       zone-offset                 offset-Z          +0000; -0800; -08:00;
```

This doesn't break the current timestamp sent by Java Kafka logger for
example, which has a timezone set to '+0000'

However this change allows the timestamp generated by Python's
'kafka-logging-handler' library to be parsed.

https://github.com/redhat-aqe/kafka-logging-handler/blob/master/kafka_logger/handlers.py#L181