### PR TITLE
Also consider key 'timestamp' for the time information

### DIFF
--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
@@ -36,6 +36,7 @@ public class LogEvent {
     public static final String MDC_EVENT_TYPE_KEY = "process_stage_step";
 
     public static final String TIMESTAMP_KEY = "@timestamp";
+    public static final String TIMESTAMP_ALT_KEY = "timestamp";
 
     public static final String MESSAGE_KEY = "message";
 
@@ -108,7 +109,7 @@ public class LogEvent {
     private void init(JsonNode jsonNode) {
         message = objectMapper.convertValue(jsonNode, new TypeReference<Map<String, Object>>() {});
         logger.trace("New log event {}.", message);
-        String time = (String) message.get(TIMESTAMP_KEY);
+        String time = (String) message.getOrDefault(TIMESTAMP_KEY, message.get(TIMESTAMP_ALT_KEY));
 
         TemporalAccessor accessor = DATE_TIME_FORMATTER.parse(time);
         this.time = Instant.from(accessor);


### PR DESCRIPTION
By default, the log event processor only uses '@timestamp' key to get
the time of the event. This commit introduces changes to also consider
key 'timestamp' as a fallback if '@timestamp' key is not present.

This is the case for the Python's 'kafka-logging-handler' library which
sets the 'timestamp' key instead of '@timestamp'