### PR TITLE
rebased feature branch to expose metrics from log event duration service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,18 @@
       <version>2.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>log4j2-jboss-logmanager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/DateParser.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/DateParser.java
@@ -1,5 +1,11 @@
 package org.jboss.pnc.logprocessor.eventduration;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -8,6 +14,19 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 
 public class DateParser {
+    private static final String className = DateParser.class.getName();
+
+    @Inject
+    @Singleton
+    MeterRegistry registry;
+
+    private static Counter errCounter;
+
+    @PostConstruct
+    void initMetrics() {
+        errCounter = registry.counter(className + ".error.count");
+    }
+
     public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSXXX")
             .withZone(ZoneId.systemDefault());
@@ -25,6 +44,7 @@ public class DateParser {
                 // try next one
             }
         }
+        errCounter.increment();
         throw new DateTimeException("Invalid input datetime format [" + time + "]");
     }
 }

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/InContainerBoot.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/InContainerBoot.java
@@ -1,10 +1,15 @@
 package org.jboss.pnc.logprocessor.eventduration;
 
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.streams.KafkaStreams;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Optional;
@@ -28,15 +33,29 @@ public class InContainerBoot {
     @ConfigProperty(name = "durationsTopicName")
     Optional<String> durationsTopicName;
 
+    private static final String className = InContainerBoot.class.getName();
+
     Logger logger = Logger.getLogger(InContainerBoot.class);
 
     private Application application;
 
+    @Inject
+    MeterRegistry registry;
+
+    private Counter errCounter;
+
+    @PostConstruct
+    void initMetrics() {
+        errCounter = registry.counter(className + ".error.count");
+    }
+
+    @Timed
     public void init() throws IOException {
         Properties kafkaProperties = new Properties();
         try (FileInputStream kafkaPropertiesStream = new FileInputStream(kafkaPropertiesPath)) {
             kafkaProperties.load(kafkaPropertiesStream);
         } catch (IOException e) {
+            errCounter.increment();
             logger.error("Cannot read Kafka.properties", e);
             throw e;
         }

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/LogProcessorTopology.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/LogProcessorTopology.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.logprocessor.eventduration;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -38,6 +39,7 @@ public class LogProcessorTopology {
         this.durationsTopic = durationsTopic;
     }
 
+    @Timed
     Topology buildTopology(Properties properties) {
         StreamsBuilder builder = new StreamsBuilder();
 

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/MergeTransformer.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/MergeTransformer.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.logprocessor.eventduration;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -28,6 +29,7 @@ class MergeTransformer implements Transformer<String, LogEvent, KeyValue<String,
         store = (KeyValueStore<String, LogEvent>) context.getStateStore(LogProcessorTopology.LOG_STORE);
     }
 
+    @Timed
     @Override
     public KeyValue<String, LogEvent> transform(String key, LogEvent thisLogEvent) {
         if (thisLogEvent == null) {

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
@@ -3,6 +3,9 @@ package org.jboss.pnc.logprocessor.eventduration.domain;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -10,6 +13,9 @@ import org.jboss.pnc.logprocessor.eventduration.DateParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -25,6 +31,8 @@ import static org.jboss.pnc.api.constants.MDCKeys.PROCESS_CONTEXT_VARIANT_KEY;
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 public class LogEvent {
+
+    private static final String className = LogEvent.class.getName();
 
     private static final Logger logger = LoggerFactory.getLogger(LogEvent.class);
 
@@ -42,12 +50,26 @@ public class LogEvent {
 
     private Instant time;
 
+    @Inject
+    @Singleton
+    MeterRegistry registry;
+
+    private static Counter errCounter;
+    private static Counter warnCounter;
+
+    @PostConstruct
+    void initMetrics() {
+        errCounter = registry.counter(className + ".error.count");
+        warnCounter = registry.counter(className + ".warning.count");
+    }
+
     public String getIdentifier() {
         Map<String, String> mdc = (Map<String, String>) message.get(MDC_KEY);
         if (mdc != null) {
             String processContext = mdc.get(PROCESS_CONTEXT_KEY);
             String eventName = mdc.get(EVENT_NAME_KEY);
             if (processContext == null || processContext.equals("")) {
+                warnCounter.increment();
                 logger.warn("Missing processContext for event {}.", eventName);
             }
             String processContextVariant = mdc.get(PROCESS_CONTEXT_VARIANT_KEY);
@@ -88,6 +110,7 @@ public class LogEvent {
         try {
             jsonNode = objectMapper.readTree(serialized);
         } catch (IOException e) {
+            errCounter.increment();
             throw new SerializationException("Cannot construct object from serialized bytes.", e);
         }
         init(jsonNode);
@@ -98,6 +121,7 @@ public class LogEvent {
         try {
             jsonNode = objectMapper.readTree(serializedLogEvent);
         } catch (IOException e) {
+            errCounter.increment();
             throw new SerializationException("Cannot construct object from serialized string.", e);
         }
         init(jsonNode);
@@ -139,6 +163,7 @@ public class LogEvent {
         public void configure(Map<String, ?> configs, boolean isKey) {
         }
 
+        @Timed
         @Override
         public byte[] serialize(String topic, LogEvent logEvent) {
             if (logEvent == null) {
@@ -148,6 +173,7 @@ public class LogEvent {
             try {
                 return objectMapper.writeValueAsBytes(logEvent.message);
             } catch (Exception e) {
+                errCounter.increment();
                 throw new SerializationException("Error serializing JSON message", e);
             }
         }
@@ -163,6 +189,7 @@ public class LogEvent {
         public void configure(Map<String, ?> configs, boolean isKey) {
         }
 
+        @Timed
         @Override
         public LogEvent deserialize(String topic, byte[] bytes) {
             if (bytes == null || bytes.length == 0) {
@@ -173,6 +200,7 @@ public class LogEvent {
             try {
                 data = new LogEvent(bytes);
             } catch (Exception e) {
+                errCounter.increment();
                 throw new SerializationException(e);
             }
             return data;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ quarkus.log.console.level=INFO
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
 quarkus.log.level=INFO
 quarkus.log.category."org.jboss.pnc".level=INFO
+
+quarkus.micrometer.export.json.enabled = true


### PR DESCRIPTION
The new feature branch for exposing metrics implemented earlier this year (NCL-6291) has been rebased on top of the most recent master version. This PR is a successor of the initial PR #51. 

@thescouser89 
@vibe13 
@matejonnet 

Please, review the changes.