### PR TITLE
Update to Quarkus 2.11.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.5.2.Final</quarkus.platform.version>
-    <kafka-clients.version>2.8.0</kafka-clients.version>
+    <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>
     <tagSuffix />
   </properties>
@@ -109,7 +108,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams-test-utils</artifactId>
-      <version>${kafka-clients.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/jboss/pnc/logprocessor/eventduration/TopologyTest.java
+++ b/src/test/java/org/jboss/pnc/logprocessor/eventduration/TopologyTest.java
@@ -1,13 +1,14 @@
 package org.jboss.pnc.logprocessor.eventduration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.jboss.pnc.logprocessor.eventduration.domain.LogEvent;
 import org.jboss.pnc.logprocessor.eventduration.utils.LogEventFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -32,7 +34,7 @@ public class TopologyTest {
     private LogEventFactory logEventFactory = new LogEventFactory();
 
     private static TopologyTestDriver testDriver;
-    private static ConsumerRecordFactory<String, LogEvent> recordFactory;
+    private static TestInputTopic<String, LogEvent> inputTopic;
 
     @BeforeEach
     public void setup() {
@@ -49,11 +51,7 @@ public class TopologyTest {
         Topology topology = logProcessorTopology.buildTopology(props);
 
         testDriver = new TopologyTestDriver(topology, props);
-
-        recordFactory = new ConsumerRecordFactory<>(
-                "input-topic",
-                new StringSerializer(),
-                new LogEvent.JsonSerializer());
+        inputTopic = testDriver.createInputTopic("input-topic", new StringSerializer(), new LogEvent.JsonSerializer());
     }
 
     @AfterEach
@@ -72,39 +70,39 @@ public class TopologyTest {
 
         // BEGIN event
         LogEvent startEvent = logEventFactory.getLogEvent(now, LogEvent.EventType.BEGIN, processContext, eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEvent));
+        inputTopic.pipeInput(startEvent);
 
         // Noise to test matching
         Instant latter = now.plus(10, MILLIS);
         LogEvent startEventOther = logEventFactory
                 .getLogEvent(latter, LogEvent.EventType.BEGIN, "other-context", eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEventOther));
+        inputTopic.pipeInput(startEventOther);
 
         // Noise to test matching
         LogEvent endEventOther = logEventFactory
                 .getLogEvent(now.plus(20, MILLIS), LogEvent.EventType.END, "other-context", eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEventOther));
+        inputTopic.pipeInput(endEventOther);
 
         // END event
         LogEvent endEvent = logEventFactory.getLogEvent(later, LogEvent.EventType.END, processContext, eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEvent));
+        inputTopic.pipeInput(endEvent);
 
-        ProducerRecord<String, LogEvent> outputRecordStart = readOutput();
-        Assertions.assertNotNull(outputRecordStart.value());
-        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value().getEventType().get());
+        KeyValue<String, LogEvent> outputRecordStart = readOutput();
+        Assertions.assertNotNull(outputRecordStart.value);
+        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value.getEventType().get());
 
         // two non matching noise events
         readOutput();
         readOutput();
 
-        ProducerRecord<String, LogEvent> outputRecordEnd = readOutputTopic("output-topic");
-        Assertions.assertNotNull(outputRecordEnd.value());
-        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value().getEventType().get());
-        int operationTook = (Integer) outputRecordEnd.value().getMessage().get(DURATION_KEY);
+        KeyValue<String, LogEvent> outputRecordEnd = readOutputTopic("output-topic");
+        Assertions.assertNotNull(outputRecordEnd.value);
+        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value.getEventType().get());
+        int operationTook = (Integer) outputRecordEnd.value.getMessage().get(DURATION_KEY);
         Assertions.assertEquals(duration.toMillis(), operationTook);
     }
 
-    private ProducerRecord<String, LogEvent> readOutput() {
+    private KeyValue<String, LogEvent> readOutput() {
         return readOutputTopic("output-topic");
     }
 
@@ -117,19 +115,19 @@ public class TopologyTest {
         Instant later = now.plus(duration);
 
         LogEvent endEvent = logEventFactory.getLogEvent(later, LogEvent.EventType.END, processContext, "");
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEvent));
+        inputTopic.pipeInput(endEvent);
 
         LogEvent startEvent = logEventFactory.getLogEvent(now, LogEvent.EventType.BEGIN, processContext, "");
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEvent));
+        inputTopic.pipeInput(startEvent);
 
-        ProducerRecord<String, LogEvent> outputRecordStart = readOutputTopic("output-topic");
-        Assertions.assertNotNull(outputRecordStart.value());
-        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value().getEventType().get());
+        KeyValue<String, LogEvent> outputRecordStart = readOutputTopic("output-topic");
+        Assertions.assertNotNull(outputRecordStart.value);
+        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value.getEventType().get());
 
-        ProducerRecord<String, LogEvent> outputRecordEnd = readOutputTopic("output-topic");
-        Assertions.assertNotNull(outputRecordEnd.value());
-        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value().getEventType().get());
-        int operationTook = (Integer) outputRecordEnd.value().getMessage().get(DURATION_KEY);
+        KeyValue<String, LogEvent> outputRecordEnd = readOutputTopic("output-topic");
+        Assertions.assertNotNull(outputRecordEnd.value);
+        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value.getEventType().get());
+        int operationTook = (Integer) outputRecordEnd.value.getMessage().get(DURATION_KEY);
         Assertions.assertEquals(duration.toMillis(), operationTook);
     }
 
@@ -142,18 +140,18 @@ public class TopologyTest {
         Instant later = now.plus(duration);
 
         LogEvent startEvent = logEventFactory.getLogEvent(now, LogEvent.EventType.BEGIN, processContext, "");
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEvent));
+        inputTopic.pipeInput(startEvent);
 
         LogEvent endEvent = logEventFactory.getLogEvent(later, LogEvent.EventType.END, processContext, "");
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEvent));
+        inputTopic.pipeInput(endEvent);
 
-        ProducerRecord<String, LogEvent> outputRecordEnd = readOutputTopic("durations-topic");
-        Assertions.assertNotNull(outputRecordEnd.value());
-        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value().getEventType().get());
-        int operationTook = (Integer) outputRecordEnd.value().getMessage().get(DURATION_KEY);
+        KeyValue<String, LogEvent> outputRecordEnd = readOutputTopic("durations-topic");
+        Assertions.assertNotNull(outputRecordEnd.value);
+        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value.getEventType().get());
+        int operationTook = (Integer) outputRecordEnd.value.getMessage().get(DURATION_KEY);
         Assertions.assertEquals(duration.toMillis(), operationTook);
 
-        ProducerRecord<String, LogEvent> outputRecordStart = readOutputTopic("durations-topic");
+        KeyValue<String, LogEvent> outputRecordStart = readOutputTopic("durations-topic");
         Assertions.assertNull(outputRecordStart);
     }
 
@@ -169,12 +167,12 @@ public class TopologyTest {
 
         // BEGIN event
         LogEvent startEvent = logEventFactory.getLogEvent(now, LogEvent.EventType.BEGIN, processContext, eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEvent));
+        inputTopic.pipeInput(startEvent);
 
         // BEGIN event with variant
         LogEvent startEventVariant = logEventFactory
                 .getLogEvent(now, LogEvent.EventType.BEGIN, processContext, processContextVariant, eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, startEventVariant));
+        inputTopic.pipeInput(startEventVariant);
 
         // Noise to test matching
         LogEvent endEventVariant = logEventFactory.getLogEvent(
@@ -183,36 +181,42 @@ public class TopologyTest {
                 processContext,
                 processContextVariant,
                 eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEventVariant));
+        inputTopic.pipeInput(endEventVariant);
 
         // END event
         LogEvent endEvent = logEventFactory
                 .getLogEvent(now.plus(duration), LogEvent.EventType.END, processContext, eventName);
-        testDriver.pipeInput(recordFactory.create("input-topic", null, endEvent));
+        inputTopic.pipeInput(endEvent);
 
         // start event
-        ProducerRecord<String, LogEvent> outputRecordStart = readOutput();
-        Assertions.assertNotNull(outputRecordStart.value());
-        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value().getEventType().get());
+        KeyValue<String, LogEvent> outputRecordStart = readOutput();
+        Assertions.assertNotNull(outputRecordStart.value);
+        Assertions.assertEquals(LogEvent.EventType.BEGIN, outputRecordStart.value.getEventType().get());
 
         // start variant event
         readOutput();
 
         // end variant event
-        ProducerRecord<String, LogEvent> outputVariantRecordEnd = readOutput();
-        Assertions.assertNotNull(outputVariantRecordEnd.value());
-        Assertions.assertEquals(LogEvent.EventType.END, outputVariantRecordEnd.value().getEventType().get());
-        int variantOperationTook = (Integer) outputVariantRecordEnd.value().getMessage().get(DURATION_KEY);
+        KeyValue<String, LogEvent> outputVariantRecordEnd = readOutput();
+        Assertions.assertNotNull(outputVariantRecordEnd.value);
+        Assertions.assertEquals(LogEvent.EventType.END, outputVariantRecordEnd.value.getEventType().get());
+        int variantOperationTook = (Integer) outputVariantRecordEnd.value.getMessage().get(DURATION_KEY);
         Assertions.assertEquals(variantDuration.toMillis(), variantOperationTook);
 
-        ProducerRecord<String, LogEvent> outputRecordEnd = readOutput();
-        Assertions.assertNotNull(outputRecordEnd.value());
-        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value().getEventType().get());
-        int operationTook = (Integer) outputRecordEnd.value().getMessage().get(DURATION_KEY);
+        KeyValue<String, LogEvent> outputRecordEnd = readOutput();
+        Assertions.assertNotNull(outputRecordEnd.value);
+        Assertions.assertEquals(LogEvent.EventType.END, outputRecordEnd.value.getEventType().get());
+        int operationTook = (Integer) outputRecordEnd.value.getMessage().get(DURATION_KEY);
         Assertions.assertEquals(duration.toMillis(), operationTook);
     }
 
-    private ProducerRecord<String, LogEvent> readOutputTopic(String topic) {
-        return testDriver.readOutput(topic, new StringDeserializer(), new LogEvent.JsonDeserializer());
+    private KeyValue<String, LogEvent> readOutputTopic(String topic) {
+        TestOutputTopic<String, LogEvent> outputTopic = testDriver
+                .createOutputTopic(topic, new StringDeserializer(), new LogEvent.JsonDeserializer());
+        try {
+            return outputTopic.readKeyValue();
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
We don't need to specify the version for kafka-streams-test-utils since
it is now part of the quarkus bom universe.

Updating to Quarkus 2.11.2.Final with a newer Kafka stream version
(3.1.0) flagged some classes that are now gone.

Using this
[guide](https://cwiki.apache.org/confluence/display/KAFKA/KIP-470%3A+TopologyTestDriver+test+input+and+output+usability+improvements),
we had to update `TopologyTest` to use the new classes.