### PR TITLE
Downgrade Quarkus to 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.12.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>
     <tagSuffix />
   </properties>


### PR DESCRIPTION
This is the last version that uploads uber jars to Maven Central. The issue with the latest Quarkus version will be fixed in a future release.