### PR TITLE
[NCL-8159] Add support to send output to different partitions

### DIFF
--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/domain/LogEvent.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.annotation.Timed;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -13,9 +11,6 @@ import org.jboss.pnc.logprocessor.eventduration.DateParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -52,26 +47,12 @@ public class LogEvent {
 
     private Instant time;
 
-    @Inject
-    @Singleton
-    MeterRegistry registry;
-
-    private static Counter errCounter;
-    private static Counter warnCounter;
-
-    @PostConstruct
-    void initMetrics() {
-        errCounter = registry.counter(className + ".error.count");
-        warnCounter = registry.counter(className + ".warning.count");
-    }
-
     public String getIdentifier() {
         Map<String, String> mdc = (Map<String, String>) message.get(MDC_KEY);
         if (mdc != null) {
             String processContext = mdc.get(PROCESS_CONTEXT_KEY);
             String eventName = mdc.get(EVENT_NAME_KEY);
             if (processContext == null || processContext.equals("")) {
-                warnCounter.increment();
                 logger.warn("Missing processContext for event {}.", eventName);
             }
             String processContextVariant = mdc.get(PROCESS_CONTEXT_VARIANT_KEY);
@@ -112,7 +93,6 @@ public class LogEvent {
         try {
             jsonNode = objectMapper.readTree(serialized);
         } catch (IOException e) {
-            errCounter.increment();
             throw new SerializationException("Cannot construct object from serialized bytes.", e);
         }
         init(jsonNode);
@@ -123,7 +103,6 @@ public class LogEvent {
         try {
             jsonNode = objectMapper.readTree(serializedLogEvent);
         } catch (IOException e) {
-            errCounter.increment();
             throw new SerializationException("Cannot construct object from serialized string.", e);
         }
         init(jsonNode);
@@ -175,6 +154,20 @@ public class LogEvent {
         }
     }
 
+    public Optional<String> getMdcProcessContext() {
+        Map<String, String> mdc = (Map<String, String>) message.get(MDC_KEY);
+        if (mdc != null) {
+            String processContext = mdc.get(PROCESS_CONTEXT_KEY);
+            if (processContext != null) {
+                return Optional.of(processContext);
+            } else {
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
     public static class JsonSerializer implements Serializer<LogEvent> {
 
         @Override
@@ -191,7 +184,6 @@ public class LogEvent {
             try {
                 return objectMapper.writeValueAsBytes(logEvent.message);
             } catch (Exception e) {
-                errCounter.increment();
                 throw new SerializationException("Error serializing JSON message", e);
             }
         }
@@ -218,7 +210,6 @@ public class LogEvent {
             try {
                 data = new LogEvent(bytes);
             } catch (Exception e) {
-                errCounter.increment();
                 throw new SerializationException(e);
             }
             return data;


### PR DESCRIPTION
This is done while preserving message ordering for a specific build (which has a specific process context mdc value) by sending those messages to the same partition. It is performed by setting the key of the output message (if not already set) to the process context mdc value.

If the key is not set, then we set the key to a Default value. This ensures that any messages with no keys are sent to the same partition.

This allows apps like Bifrost to run multiple instances to consume messages from log-event-duration by having multiple partitions to consume the data.