### PR TITLE
Migrate Kafka stream transformer to the processor API

### DIFF
--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/LogProcessorTopology.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/LogProcessorTopology.java
@@ -57,7 +57,7 @@ public class LogProcessorTopology {
                 .withLoggingEnabled(configuration);
         builder.addStateStore(storageStoreBuilder);
 
-        KStream<String, LogEvent> output = input.transform(MergeTransformer::new, LOG_STORE);
+        KStream<String, LogEvent> output = input.process(new MergeProcessorSupplier(), LOG_STORE);
 
         output.to(outputTopic, Produced.with(Serdes.String(), logSerde));
 

--- a/src/main/java/org/jboss/pnc/logprocessor/eventduration/MergeProcessorSupplier.java
+++ b/src/main/java/org/jboss/pnc/logprocessor/eventduration/MergeProcessorSupplier.java
@@ -1,0 +1,13 @@
+package org.jboss.pnc.logprocessor.eventduration;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.jboss.pnc.logprocessor.eventduration.domain.LogEvent;
+
+public class MergeProcessorSupplier implements ProcessorSupplier<String, LogEvent, String, LogEvent> {
+
+    @Override
+    public Processor<String, LogEvent, String, LogEvent> get() {
+        return new MergeProcessor();
+    }
+}

--- a/src/test/java/org/jboss/pnc/logprocessor/eventduration/TopologyTest.java
+++ b/src/test/java/org/jboss/pnc/logprocessor/eventduration/TopologyTest.java
@@ -240,7 +240,7 @@ public class TopologyTest {
         // READ
         KeyValue<String, LogEvent> outputRecordEnd = readOutput();
         Assertions.assertNotNull(outputRecordEnd.value);
-        Assertions.assertEquals(MergeTransformer.DEFAULT_KAFKA_MESSAGE_KEY, outputRecordEnd.key);
+        Assertions.assertEquals(MergeProcessor.DEFAULT_KAFKA_MESSAGE_KEY, outputRecordEnd.key);
 
     }
 


### PR DESCRIPTION
The transformer API is removed in the kafka 4 APIs